### PR TITLE
Fix: close master pr workflow permissions

### DIFF
--- a/.github/workflows/close-master-pr.yml
+++ b/.github/workflows/close-master-pr.yml
@@ -9,19 +9,10 @@ jobs:
     runs-on: ubuntu-latest
     if: ${{(github.head_ref == 'master' || github.head_ref == 'main' || github.head_ref == 'develop' || github.head_ref == 'stable' || github.head_ref == 'staging')
         && github.event.pull_request.head.repo.fork}}
-
+    permissions:
+      contents: read
+      pull-requests: write
     steps:
     - uses: superbrothers/close-pull-request@v3
       with:
         comment: "Thank you for your contribution! It appears you created a pull request from the master branch or another main development branch. This is [something you should avoid doing](https://jmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/), and thus this pull request has been automatically closed. \n \n We suggest you follow [our git usage documentation](https://docs.spacestation14.com/en/general-development/setup/git-for-the-ss14-developer.html). \n \n You can move your current work to another branch by following [these commands](https://ohshitgit.com/#accidental-commit-master). Then, you may recreate your pull request using the new branch."
-
-    # If you prefer to just comment on the pr and not close it, uncomment the below and comment the above
-
-    # - uses: actions/github-script@v7
-    #   with:
-    #     script: |
-    #       github.rest.issues.createComment({
-    #         issue_number: ${{ github.event.number }},
-    #         owner: context.repo.owner,
-    #         repo: context.repo.repo,
-    #         body: "Thank you for your contribution! It appears you created a pull request from the master branch or another main development branch. This is [something you should avoid doing](https://jmeridth.com/posts/do-not-issue-pull-requests-from-your-master-branch/)\n\nYou can move your current work to another branch by following [these commands](https://ohshitgit.com/#accidental-commit-master). Then, you may recreate your pull request using the new branch. \n\n This pull request won't be automatically closed. However, a maintainer may close it for this reason."})


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do
Fixes the auto close prs from master branches workflow and cleans it up

## Testing
No
<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from Paradise SS14 -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] MIT (https://github.com/ParadiseSS14/Paradise14/blob/master/LICENSE-MIT.txt) <!-- This is required to contribute to ParadiseSS14 -->
    <!-- Feel free to add more licenses as you see fit -->
