### PR TITLE
Port Wall Mount Directional Visibility from Wizden

### DIFF
--- a/Content.Client/Wall/Components/WallMountTreeComponent.cs
+++ b/Content.Client/Wall/Components/WallMountTreeComponent.cs
@@ -1,0 +1,15 @@
+using Content.Shared.Wall;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.Physics;
+
+namespace Content.Client.Wall.Components;
+
+/// <summary>
+/// Stores a component tree of <see cref="WallMountComponent"/>.
+/// </summary>
+[RegisterComponent]
+public sealed partial class WallMountTreeComponent : Component, IComponentTreeComponent<WallMountComponent>
+{
+    /// <inheritdoc/>
+    public DynamicTree<ComponentTreeEntry<WallMountComponent>> Tree { get; set; } = default!;
+}

--- a/Content.Client/Wall/Systems/WallMountTreeSystem.cs
+++ b/Content.Client/Wall/Systems/WallMountTreeSystem.cs
@@ -1,0 +1,31 @@
+using System.Numerics;
+using Content.Client.Wall.Components;
+using Content.Shared.Wall;
+using Robust.Client.GameObjects;
+using Robust.Shared.ComponentTrees;
+using Robust.Shared.Physics;
+
+namespace Content.Client.Wall.Systems;
+
+/// <summary>
+/// Maintains the <see cref="WallMountTreeComponent"/> component tree.
+/// </summary>
+public sealed partial class WallMountTreeSystem : ComponentTreeSystem<WallMountTreeComponent, WallMountComponent>
+{
+    [Dependency] private SpriteSystem _sprite = default!;
+
+    /// <inheritdoc/>
+    protected override bool DoFrameUpdate => true;
+
+    /// <inheritdoc/>
+    protected override bool DoTickUpdate => false;
+
+    /// <inheritdoc/>
+    protected override bool Recursive => false;
+
+    /// <inheritdoc/>
+    protected override Box2 ExtractAabb(in ComponentTreeEntry<WallMountComponent> entry, Vector2 pos, Angle rot)
+    {
+        return _sprite.CalculateBounds((entry.Uid, Comp<SpriteComponent>(entry.Uid)), pos, rot, default).CalcBoundingBox();
+    }
+}

--- a/Content.Client/Wall/Systems/WallMountVisibilitySystem.cs
+++ b/Content.Client/Wall/Systems/WallMountVisibilitySystem.cs
@@ -1,0 +1,112 @@
+using Content.Shared.CCVar;
+using Content.Shared.Wall;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Configuration;
+using Robust.Shared.Map.Components;
+
+namespace Content.Client.Wall.Systems;
+
+/// <summary>
+/// Manages the directional visibility overlay for wall-mounted entities.
+/// </summary>
+public sealed partial class WallMountVisibilitySystem : EntitySystem
+{
+    [Dependency] private IConfigurationManager _cfg = default!;
+    [Dependency] private IOverlayManager _overlay = default!;
+    [Dependency] private SharedMapSystem _map = default!;
+    [Dependency] private SpriteSystem _sprite = default!;
+
+    private WallMountVisibilityOverlay _overlayInstance = default!;
+
+    /// <summary>
+    /// Whether directional visibility is currently enabled.
+    /// </summary>
+    public bool DirectionalVisibilityEnabled = true;
+
+    /// <summary>
+    /// Whether wall-mount visibility changes fade smoothly or snap instantly.
+    /// </summary>
+    public bool FadeEnabled = true;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+
+        _overlayInstance = new WallMountVisibilityOverlay();
+
+        Subs.CVar(_cfg, CCVars.WallMountDirectionalVisibility, OnDirectionalVisibilityChanged, true);
+        Subs.CVar(_cfg, CCVars.WallMountFade, OnFadeChanged, true);
+    }
+
+    public override void Shutdown()
+    {
+        base.Shutdown();
+
+        _overlay.RemoveOverlay(_overlayInstance);
+    }
+
+    private void OnDirectionalVisibilityChanged(bool enabled)
+    {
+        DirectionalVisibilityEnabled = enabled;
+
+        if (enabled)
+            _overlay.AddOverlay(_overlayInstance);
+        else
+        {
+            _overlay.RemoveOverlay(_overlayInstance);
+            _overlayInstance.RestoreAll();
+        }
+    }
+
+    private void OnFadeChanged(bool enabled)
+    {
+        FadeEnabled = enabled;
+    }
+
+    /// <summary>
+    /// Makes the entity visible again on component shutdown.
+    /// </summary>
+    [SubscribeLocalEvent]
+    private void OnWallMountShutdown(Entity<WallMountComponent> ent, ref ComponentShutdown args)
+    {
+        if (TerminatingOrDeleted(ent))
+            return;
+
+        if (!TryComp<SpriteComponent>(ent, out var sprite))
+            return;
+
+        _sprite.SetVisible((ent, sprite), true);
+    }
+
+    /// <summary>
+    /// Makes the entity visible again if directional visibility is disabled for this mount.
+    /// </summary>
+    [SubscribeLocalEvent]
+    private void OnWallMountAfterHandleState(Entity<WallMountComponent> ent, ref AfterAutoHandleStateEvent args)
+    {
+        if (ent.Comp.DirectionalVisibility)
+            return;
+
+        if (!TryComp<SpriteComponent>(ent, out var sprite))
+            return;
+
+        _sprite.SetVisible((ent, sprite), true);
+    }
+
+    /// <summary>
+    /// Checks whether the tile contains any anchored blocking entity.
+    /// </summary>
+    public bool IsTileBlocked(Entity<MapGridComponent> grid, Vector2i tile)
+    {
+        var enumerator = _map.GetAnchoredEntitiesEnumerator(grid.Owner, grid, tile);
+        while (enumerator.MoveNext(out var anchored))
+        {
+            if (!HasComp<WallComponent>(anchored.Value))
+                continue;
+
+            return true;
+        }
+        return false;
+    }
+}

--- a/Content.Client/Wall/WallMountFadeState.cs
+++ b/Content.Client/Wall/WallMountFadeState.cs
@@ -1,0 +1,99 @@
+using Robust.Client.GameObjects;
+
+namespace Content.Client.Wall;
+
+/// <summary>
+/// Tracks fade progress for a wall-mounted entity.
+/// </summary>
+public struct WallMountFadeState
+{
+    /// <summary>
+    /// The sprite's original alpha before any fade was applied.
+    /// </summary>
+    public float OriginalAlpha;
+
+    /// <summary>
+    /// The current fade multiplier.
+    /// </summary>
+    public float CurrentAlpha;
+
+    /// <summary>
+    /// The target fade multiplier.
+    /// </summary>
+    public float TargetAlpha;
+
+    /// <summary>
+    /// Sprite alpha after applying the fade multiplier.
+    /// </summary>
+    public readonly float EffectiveAlpha => OriginalAlpha * CurrentAlpha;
+
+    /// <summary>
+    /// Whether the entity should be rendered as visible at the current fade level.
+    /// </summary>
+    public readonly bool IsVisible => CurrentAlpha > 0f;
+
+    /// <summary>
+    /// Creates a new fade state snapped immediately to the given target alpha.
+    /// </summary>
+    public static WallMountFadeState Snapped(float originalAlpha, float targetAlpha)
+    {
+        return new()
+        {
+            OriginalAlpha = originalAlpha,
+            CurrentAlpha = targetAlpha,
+            TargetAlpha = targetAlpha,
+        };
+    }
+
+    /// <summary>
+    /// Moves <see cref="CurrentAlpha"/> one step towards <see cref="TargetAlpha"/>.
+    /// </summary>
+    public void StepTowards(float fadeStep)
+    {
+        if (MathHelper.CloseTo(CurrentAlpha, TargetAlpha))
+            return;
+
+        var delta = TargetAlpha - CurrentAlpha;
+        var step = MathF.Sign(delta) * MathF.Min(MathF.Abs(delta), fadeStep);
+        CurrentAlpha = Math.Clamp(CurrentAlpha + step, 0f, 1f);
+    }
+}
+
+/// <summary>
+/// Per-viewport fade state for wall-mounted entities.
+/// </summary>
+public sealed class ViewportFadeState(SpriteSystem sprite, EntityQuery<SpriteComponent> spriteQuery) : IDisposable
+{
+    private readonly SpriteSystem _sprite = sprite;
+    private readonly EntityQuery<SpriteComponent> _spriteQuery = spriteQuery;
+
+    /// <summary>
+    /// Fade states for entities tracked in this viewport.
+    /// </summary>
+    public readonly Dictionary<EntityUid, WallMountFadeState> FadeStates = [];
+
+    /// <summary>
+    /// Entities visible this frame.
+    /// </summary>
+    public readonly HashSet<EntityUid> SeenThisFrame = [];
+
+    /// <summary>
+    /// Whether FOV was enabled during the previous frame.
+    /// </summary>
+    public bool WasFovEnabled = true;
+
+    public void Dispose()
+    {
+        foreach (var (uid, state) in FadeStates)
+        {
+            if (!_spriteQuery.TryGetComponent(uid, out var sprite))
+                continue;
+
+            _sprite.SetColor((uid, sprite), sprite.Color.WithAlpha(state.OriginalAlpha));
+            _sprite.SetVisible((uid, sprite), true);
+        }
+
+        FadeStates.Clear();
+        SeenThisFrame.Clear();
+    }
+}

--- a/Content.Client/Wall/WallMountVisibilityOverlay.cs
+++ b/Content.Client/Wall/WallMountVisibilityOverlay.cs
@@ -1,0 +1,275 @@
+using System.Numerics;
+using Content.Client.Graphics;
+using Content.Client.Wall.Systems;
+using Content.Shared.Wall;
+using Robust.Client.GameObjects;
+using Robust.Client.Graphics;
+using Robust.Shared.Enums;
+using Robust.Shared.Graphics;
+using Robust.Shared.Map.Components;
+using Robust.Shared.Timing;
+
+namespace Content.Client.Wall;
+
+/// <summary>
+/// Manages the visibility of wall-mounted entities based on their facing arc relative to the viewport's eye.
+/// </summary>
+public sealed partial class WallMountVisibilityOverlay : Overlay
+{
+    [Dependency] private IEntityManager _entManager = default!;
+    [Dependency] private IGameTiming _timing = default!;
+
+    private readonly SharedMapSystem _map;
+    private readonly SpriteSystem _sprite;
+    private readonly TransformSystem _xform;
+    private readonly WallMountTreeSystem _tree;
+    private readonly WallMountVisibilitySystem _visibility;
+
+    private readonly EntityQuery<MapGridComponent> _gridQuery;
+    private readonly EntityQuery<SpriteComponent> _spriteQuery;
+
+    public WallMountVisibilityOverlay()
+    {
+        IoCManager.InjectDependencies(this);
+
+        _map = _entManager.System<SharedMapSystem>();
+        _sprite = _entManager.System<SpriteSystem>();
+        _xform = _entManager.System<TransformSystem>();
+        _tree = _entManager.System<WallMountTreeSystem>();
+        _visibility = _entManager.System<WallMountVisibilitySystem>();
+
+        _gridQuery = _entManager.GetEntityQuery<MapGridComponent>();
+        _spriteQuery = _entManager.GetEntityQuery<SpriteComponent>();
+    }
+
+    /// <summary>
+    /// Caches <see cref="ViewportFadeState"/> instances per viewport.
+    /// </summary>
+    private readonly OverlayResourceCache<ViewportFadeState> _fadeCache = new();
+
+    /// <summary>
+    /// Original sprite alphas, shared across viewports to avoid capturing values modified by another viewport.
+    /// </summary>
+    private readonly Dictionary<EntityUid, float> _originalAlphas = [];
+
+    /// <summary>
+    /// Entities to remove from fade tracking.
+    /// </summary>
+    private readonly List<EntityUid> _toRemove = [];
+
+    /// <summary>
+    /// Alpha change per second during fade.
+    /// </summary>
+    private const float FadeSpeed = 9f;
+
+    public override OverlaySpace Space => OverlaySpace.WorldSpaceBelowEntities;
+
+    protected override void Draw(in OverlayDrawArgs args)
+    {
+        if (!_visibility.DirectionalVisibilityEnabled)
+            return;
+
+        if (args.Viewport.Eye is not { } eye)
+            return;
+
+        var viewportState = _fadeCache.GetForViewport(args.Viewport, _ => new ViewportFadeState(_sprite, _spriteQuery));
+
+        if (!eye.DrawFov)
+        {
+            HandleFovDisabled(args, viewportState);
+            return;
+        }
+
+        viewportState.WasFovEnabled = true;
+
+        var fadeStep = _visibility.FadeEnabled ? FadeSpeed * (float)_timing.FrameTime.TotalSeconds : 1f;
+        var matrix = args.Viewport.GetWorldToLocalMatrix();
+
+        viewportState.SeenThisFrame.Clear();
+        ProcessVisibleEntities(args, eye, matrix, fadeStep, viewportState);
+
+        // Remove entities that left the viewport this frame.
+        _toRemove.Clear();
+        foreach (var uid in viewportState.FadeStates.Keys)
+        {
+            if (!viewportState.SeenThisFrame.Contains(uid))
+                _toRemove.Add(uid);
+        }
+        foreach (var uid in _toRemove)
+        {
+            RemoveTrackedEntity(uid, viewportState);
+        }
+
+        ApplyFadeToVisibleEntities(viewportState);
+    }
+
+    /// <summary>
+    /// When FOV gets disabled, clears fade state and restores sprites.
+    /// On subsequent frames, keeps wall-mounts visible and restores alpha modified by other viewports.
+    /// </summary>
+    private void HandleFovDisabled(in OverlayDrawArgs args, ViewportFadeState viewportState)
+    {
+        if (viewportState.WasFovEnabled)
+        {
+            ClearViewportFadeState(viewportState);
+            viewportState.WasFovEnabled = false;
+        }
+
+        // Restore alpha modified by other viewports.
+        foreach (var entity in _tree.QueryAabb(args.MapId, args.WorldBounds))
+        {
+            var uid = entity.Uid;
+            if (!_spriteQuery.TryGetComponent(uid, out var sprite))
+                continue;
+
+            if (_originalAlphas.Remove(uid, out var origAlpha))
+                _sprite.SetColor((uid, sprite), sprite.Color.WithAlpha(origAlpha));
+
+            _sprite.SetVisible((uid, sprite), true);
+        }
+    }
+
+    /// <summary>
+    /// Updates fade state for all wall-mounted entities in the viewport.
+    /// </summary>
+    private void ProcessVisibleEntities(in OverlayDrawArgs args, IEye eye, Matrix3x2 matrix, float fadeStep, ViewportFadeState viewportState)
+    {
+        foreach (var entity in _tree.QueryAabb(args.MapId, args.WorldBounds))
+        {
+            var (wallmount, xform) = entity;
+            var uid = entity.Uid;
+
+            if (!_spriteQuery.TryGetComponent(uid, out var sprite))
+                continue;
+
+            // Capture original alpha before any viewport modifies it.
+            if (!_originalAlphas.TryGetValue(uid, out var originalAlpha))
+                _originalAlphas[uid] = originalAlpha = sprite.Color.A;
+
+            viewportState.SeenThisFrame.Add(uid);
+
+            var targetAlpha = ComputeTargetAlpha(wallmount, xform, eye, matrix);
+            UpdateFadeState(uid, originalAlpha, targetAlpha, fadeStep, viewportState);
+        }
+    }
+
+    /// <summary>
+    /// Returns 1 if the entity is within its facing arc relative to the eye, 0 otherwise.
+    /// </summary>
+    private float ComputeTargetAlpha(WallMountComponent wallmount, TransformComponent xform, IEye eye, Matrix3x2 matrix)
+    {
+        if (!wallmount.DirectionalVisibility || wallmount.Arc >= Math.Tau)
+            return 1f;
+
+        if (xform.GridUid is not { } gridUid || !_gridQuery.TryGetComponent(gridUid, out var grid))
+            return 1f;
+
+        var tile = _map.TileIndicesFor(gridUid, grid, xform.Coordinates);
+        if (!_visibility.IsTileBlocked((gridUid, grid), tile))
+            return 1f;
+
+        var (pos, rot) = _xform.GetWorldPositionRotation(xform);
+        var facingAngle = rot + eye.Rotation + wallmount.Direction;
+
+        var entityScreenPos = Vector2.Transform(pos, matrix);
+        var eyeScreenPos = Vector2.Transform(eye.Position.Position, matrix);
+        var toEntity = entityScreenPos - eyeScreenPos;
+        var eyeToEntityAngle = (toEntity with { X = -toEntity.X }).ToWorldAngle();
+
+        var angleDiff = Angle.ShortestDistance(eyeToEntityAngle, facingAngle);
+        return Math.Abs(angleDiff) < wallmount.Arc / 2 ? 1f : 0f;
+    }
+
+    /// <summary>
+    /// Applies the current fade state to all entities seen this frame.
+    /// </summary>
+    private void ApplyFadeToVisibleEntities(ViewportFadeState viewportState)
+    {
+        foreach (var uid in viewportState.SeenThisFrame)
+        {
+            if (!viewportState.FadeStates.TryGetValue(uid, out var state))
+                continue;
+
+            if (!_spriteQuery.TryGetComponent(uid, out var sprite))
+            {
+                RemoveTrackedEntity(uid, viewportState);
+                continue;
+            }
+
+            _sprite.SetColor((uid, sprite), sprite.Color.WithAlpha(state.EffectiveAlpha));
+            _sprite.SetVisible((uid, sprite), state.IsVisible);
+        }
+    }
+
+    /// <summary>
+    /// Updates fade target for a tracked entity. Newly seen entities snap immediately without fading.
+    /// </summary>
+    private static void UpdateFadeState(EntityUid uid, float originalAlpha, float targetAlpha, float fadeStep, ViewportFadeState viewportState)
+    {
+        if (viewportState.FadeStates.TryGetValue(uid, out var state))
+        {
+            state.TargetAlpha = targetAlpha;
+            state.StepTowards(fadeStep);
+            viewportState.FadeStates[uid] = state;
+            return;
+        }
+
+        viewportState.FadeStates[uid] = WallMountFadeState.Snapped(originalAlpha, targetAlpha);
+    }
+
+
+    /// <summary>
+    /// Restores the sprite color and visibility.
+    /// </summary>
+    private void RestoreSprite(EntityUid uid, WallMountFadeState state)
+    {
+        if (!_spriteQuery.TryGetComponent(uid, out var sprite))
+            return;
+
+        _sprite.SetColor((uid, sprite), sprite.Color.WithAlpha(state.OriginalAlpha));
+        _sprite.SetVisible((uid, sprite), true);
+    }
+
+    /// <summary>
+    /// Removes an entity from fade tracking and restores its sprite.
+    /// </summary>
+    private void RemoveTrackedEntity(EntityUid uid, ViewportFadeState viewportState)
+    {
+        if (viewportState.FadeStates.Remove(uid, out var state))
+            RestoreSprite(uid, state);
+
+        _originalAlphas.Remove(uid);
+    }
+
+    /// <summary>
+    /// Clears all fade tracking for a viewport and restores sprites.
+    /// </summary>
+    private void ClearViewportFadeState(ViewportFadeState viewportState)
+    {
+        foreach (var (uid, state) in viewportState.FadeStates)
+        {
+            RestoreSprite(uid, state);
+            _originalAlphas.Remove(uid);
+        }
+
+        viewportState.FadeStates.Clear();
+        viewportState.SeenThisFrame.Clear();
+    }
+
+    /// <summary>
+    /// Restores all tracked sprites and clears all fade states.
+    /// </summary>
+    public void RestoreAll()
+    {
+        _fadeCache.Dispose();
+        _originalAlphas.Clear();
+        _toRemove.Clear();
+    }
+
+    protected override void DisposeBehavior()
+    {
+        RestoreAll();
+
+        base.DisposeBehavior();
+    }
+}

--- a/Content.Server/Construction/Commands/TileWallsCommand.cs
+++ b/Content.Server/Construction/Commands/TileWallsCommand.cs
@@ -7,6 +7,7 @@ using Robust.Shared.Map;
 using Robust.Server.GameObjects;
 using Robust.Shared.Map.Components;
 using Robust.Shared.Prototypes;
+using Content.Shared.Wall;
 
 namespace Content.Server.Construction.Commands;
 
@@ -22,7 +23,6 @@ public sealed partial class TileWallsCommand : IConsoleCommand
     public string Help => $"Usage: {Command} <gridId> | {Command}";
 
     public static readonly ProtoId<ContentTileDefinition> TilePrototypeId = "Plating";
-    public static readonly ProtoId<TagPrototype> WallTag = "Wall";
     public static readonly ProtoId<TagPrototype> DiagonalTag = "Diagonal";
 
     public void Execute(IConsoleShell shell, string argStr, string[] args)
@@ -79,7 +79,7 @@ public sealed partial class TileWallsCommand : IConsoleCommand
                 continue;
             }
 
-            if (!tagSystem.HasTag(child, WallTag))
+            if (!_entManager.HasComponent<WallComponent>(child))
             {
                 continue;
             }

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.Helpers.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.Helpers.cs
@@ -1,9 +1,8 @@
 using System.Numerics;
 using Content.Shared.Procedural;
-using Content.Shared.Tag;
+using Content.Shared.Wall;
 using Robust.Shared.Collections;
 using Robust.Shared.Map.Components;
-using Robust.Shared.Prototypes;
 
 namespace Content.Server.Procedural.DungeonJob;
 
@@ -11,15 +10,13 @@ public sealed partial class DungeonJob
 {
     // Various helper methods.
 
-    private static readonly ProtoId<TagPrototype> WallTag = "Wall";
-
     private bool HasWall(Vector2i tile)
     {
         var anchored = _maps.GetAnchoredEntitiesEnumerator(_gridUid, _grid, tile);
 
         while (anchored.MoveNext(out var uid))
         {
-            if (_tags.HasTag(uid.Value, WallTag))
+            if (_entManager.HasComponent<WallComponent>(uid.Value))
                 return true;
         }
 

--- a/Content.Server/Procedural/DungeonJob/DungeonJob.cs
+++ b/Content.Server/Procedural/DungeonJob/DungeonJob.cs
@@ -37,7 +37,6 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
     private readonly DungeonSystem _dungeon;
     private readonly EntityLookupSystem _lookup;
     private readonly EntityTableSystem _entTable;
-    private readonly TagSystem _tags;
     private readonly TileSystem _tile;
     private readonly TurfSystem _turf;
     private readonly SharedMapSystem _maps;
@@ -89,7 +88,6 @@ public sealed partial class DungeonJob : Job<List<Dungeon>>
         _lookup = lookup;
         _tile = tile;
         _turf = turf;
-        _tags = _entManager.System<TagSystem>();
         _maps = _entManager.System<SharedMapSystem>();
         _entTable = _entManager.System<EntityTableSystem>();
         _transform = transform;

--- a/Content.Shared/CCVar/CCVars.Game.cs
+++ b/Content.Shared/CCVar/CCVars.Game.cs
@@ -435,4 +435,16 @@ public sealed partial class CCVars
     /// </remarks>
     public static readonly CVarDef<string> NewCharacterJobs =
         CVarDef.Create("game.new_character_jobs", "Passenger", CVar.REPLICATED);
+
+    /// <summary>
+    /// Determines whether wall-mounted entities are hidden when viewed from outside their facing arc.
+    /// </summary>
+    public static readonly CVarDef<bool> WallMountDirectionalVisibility =
+        CVarDef.Create("game.wallmount_directional_visibility", true, CVar.SERVER | CVar.REPLICATED);
+
+    /// <summary>
+    /// Whether wall-mounted entities fade in/out when entering or leaving the facing arc.
+    /// </summary>
+    public static readonly CVarDef<bool> WallMountFade =
+        CVarDef.Create("game.wallmount_fade", true, CVar.SERVER | CVar.REPLICATED);
 }

--- a/Content.Shared/Construction/Conditions/AgainstWall.cs
+++ b/Content.Shared/Construction/Conditions/AgainstWall.cs
@@ -1,4 +1,5 @@
 using Content.Shared.Tag;
+using Content.Shared.Wall;
 using JetBrains.Annotations;
 using Robust.Shared.Map;
 using Robust.Shared.Prototypes;
@@ -13,7 +14,6 @@ namespace Content.Shared.Construction.Conditions;
 public sealed partial class AgainstWall : IConstructionCondition
 {
     private static readonly ProtoId<TagPrototype> DiagonalTag = "Diagonal";
-    private static readonly ProtoId<TagPrototype> WallTag = "Wall";
 
     /// <summary>
     /// The angle to add to the direction of the entity to point it towards the wall.
@@ -33,7 +33,7 @@ public sealed partial class AgainstWall : IConstructionCondition
 
         foreach (var entity in lookupSys.GetEntitiesIntersecting(againstLocation, LookupFlags.Approximate | LookupFlags.Static))
         {
-            if (!tagSys.HasTag(entity, WallTag))
+            if (!entManager.HasComponent<WallComponent>(entity))
                 continue;
 
             if (tagSys.HasTag(entity, DiagonalTag)

--- a/Content.Shared/Construction/Conditions/WallmountCondition.cs
+++ b/Content.Shared/Construction/Conditions/WallmountCondition.cs
@@ -1,12 +1,11 @@
 using System.Linq;
 using System.Numerics;
 using Content.Shared.Physics;
-using Content.Shared.Tag;
+using Content.Shared.Wall;
 using JetBrains.Annotations;
 using Robust.Shared.Map;
 using Robust.Shared.Physics;
 using Robust.Shared.Physics.Systems;
-using Robust.Shared.Prototypes;
 using Robust.Shared.Utility;
 
 namespace Content.Shared.Construction.Conditions
@@ -15,8 +14,6 @@ namespace Content.Shared.Construction.Conditions
     [DataDefinition]
     public sealed partial class WallmountCondition : IConstructionCondition
     {
-        private static readonly ProtoId<TagPrototype> WallTag = "Wall";
-
         public bool Condition(EntityUid user, EntityCoordinates location, Direction direction)
         {
             var entManager = IoCManager.Resolve<IEntityManager>();
@@ -42,10 +39,8 @@ namespace Content.Shared.Construction.Conditions
             var rUserToObj = new CollisionRay(userWorldPosition, userToObject.Normalized(), (int) CollisionGroup.Impassable);
             var length = userToObject.Length();
 
-            var tagSystem = entManager.System<TagSystem>();
-
             var userToObjRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rUserToObj, maxLength: length,
-                predicate: (e) => !tagSystem.HasTag(e, WallTag));
+                predicate: (e) => !entManager.HasComponent<WallComponent>(e));
 
             var targetWall = userToObjRaycastResults.FirstOrNull();
 
@@ -56,7 +51,7 @@ namespace Content.Shared.Construction.Conditions
             // check that we didn't try to build wallmount that facing another adjacent wall
             var rAdjWall = new CollisionRay(objWorldPosition, directionWithOffset.Normalized(), (int) CollisionGroup.Impassable);
             var adjWallRaycastResults = physics.IntersectRayWithPredicate(entManager.GetComponent<TransformComponent>(user).MapID, rAdjWall, maxLength: 0.5f,
-               predicate: e => e == targetWall.Value.HitEntity || !tagSystem.HasTag(e, WallTag));
+               predicate: e => e == targetWall.Value.HitEntity || !entManager.HasComponent<WallComponent>(e));
 
             return !adjWallRaycastResults.Any();
         }

--- a/Content.Shared/Pinpointer/SharedNavMapSystem.cs
+++ b/Content.Shared/Pinpointer/SharedNavMapSystem.cs
@@ -3,10 +3,12 @@ using System.Numerics;
 using System.Runtime.CompilerServices;
 using Content.Shared.Examine;
 using Content.Shared.Tag;
+using Content.Shared.Wall;
 using Robust.Shared.GameStates;
 using Robust.Shared.Network;
 using Robust.Shared.Prototypes;
 using Robust.Shared.Serialization;
+using Dependency = Robust.Shared.IoC.DependencyAttribute;
 
 namespace Content.Shared.Pinpointer;
 
@@ -23,12 +25,13 @@ public abstract partial class SharedNavMapSystem : EntitySystem
     public const int WallMask = AllDirMask << (int) NavMapChunkType.Wall;
     public const int FloorMask = AllDirMask << (int) NavMapChunkType.Floor;
 
-    [Robust.Shared.IoC.Dependency] private TagSystem _tagSystem = default!;
-    [Robust.Shared.IoC.Dependency] private INetManager _net = default!;
+    [Dependency] private TagSystem _tagSystem = default!;
+    [Dependency] private INetManager _net = default!;
 
-    [Robust.Shared.IoC.Dependency] private EntityQuery<NavMapDoorComponent> _doorQuery = default!;
+    [Dependency] private EntityQuery<NavMapDoorComponent> _doorQuery;
+    [Dependency] private EntityQuery<WallComponent> _wallQuery;
 
-    private static readonly ProtoId<TagPrototype>[] WallTags = {"Wall", "Window"};
+    private static readonly ProtoId<TagPrototype>[] WallTags = ["Window"];
 
     public override void Initialize()
     {
@@ -61,7 +64,7 @@ public abstract partial class SharedNavMapSystem : EntitySystem
         if (_doorQuery.HasComp(uid))
             return NavMapChunkType.Airlock;
 
-        if (_tagSystem.HasAnyTag(uid, WallTags))
+        if (_wallQuery.HasComp(uid) || _tagSystem.HasAnyTag(uid, WallTags))
             return NavMapChunkType.Wall;
 
         return NavMapChunkType.Invalid;

--- a/Content.Shared/Wall/WallComponent.cs
+++ b/Content.Shared/Wall/WallComponent.cs
@@ -1,0 +1,9 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Wall;
+
+/// <summary>
+/// Marks the entity as a wall.
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+public sealed partial class WallComponent : Component;

--- a/Content.Shared/Wall/WallMountComponent.cs
+++ b/Content.Shared/Wall/WallMountComponent.cs
@@ -1,28 +1,49 @@
+using Robust.Shared.ComponentTrees;
 using Robust.Shared.GameStates;
+using Robust.Shared.Physics;
 
 namespace Content.Shared.Wall;
 
 /// <summary>
-///     This component enables an entity to ignore some obstructions for interaction checks.
+/// Marks an entity as wall-mounted.
+/// Allows interaction through other anchored entities on the same tile within the <see cref="Arc"/>.
+/// Hides the sprite when viewed from outside that arc.
 /// </summary>
-/// <remarks>
-///     This will only exempt anchored entities that intersect the wall-mount. Additionally, this exemption will apply
-///     in a limited arc, providing basic functionality for directional wall mounts.
-/// </remarks>
-[RegisterComponent, NetworkedComponent, AutoGenerateComponentState]
-public sealed partial class WallMountComponent : Component
+[RegisterComponent, NetworkedComponent, AutoGenerateComponentState(raiseAfterAutoHandleState: true)]
+public sealed partial class WallMountComponent : Component, IComponentTreeEntry<WallMountComponent>
 {
     /// <summary>
-    ///     Range of angles for which the exemption applies. Bigger is more permissive.
+    /// Range of angles where interaction through other anchored entities on the same tile is allowed.
+    /// Bigger is more permissive.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("arc"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public Angle Arc = new(MathF.PI);
 
     /// <summary>
-    ///     The direction in which the exemption arc is facing, relative to the entity's rotation. Defaults to south.
+    /// The direction the allowed angle range faces, relative to the entity's rotation.
+    /// Defaults to south.
     /// </summary>
-    [ViewVariables(VVAccess.ReadWrite)]
-    [DataField("direction"), AutoNetworkedField]
+    [DataField, AutoNetworkedField]
     public Angle Direction = Angle.Zero;
+
+    /// <summary>
+    /// If true, the sprite is only visible from within the facing <see cref="Arc"/>.
+    /// </summary>
+    [DataField, AutoNetworkedField]
+    public bool DirectionalVisibility = true;
+
+    /// <inheritdoc/>
+    [ViewVariables]
+    public EntityUid? TreeUid { get; set; }
+
+    /// <inheritdoc/>
+    [ViewVariables]
+    public DynamicTree<ComponentTreeEntry<WallMountComponent>>? Tree { get; set; }
+
+    /// <inheritdoc/>
+    [ViewVariables]
+    public bool AddToTree => Arc < Math.Tau && DirectionalVisibility;
+
+    /// <inheritdoc/>
+    public bool TreeUpdateQueued { get; set; }
 }

--- a/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
+++ b/Resources/Prototypes/Entities/Mobs/Player/dragon.yml
@@ -146,7 +146,6 @@
       components:
       - MobState
       - Door
-      tags:
       - Wall
   - type: Tag
     tags:
@@ -249,7 +248,6 @@
       components:
       - MobState
       - Door
-      tags:
       - Wall
     event: !type:DevourActionEvent
 

--- a/Resources/Prototypes/Entities/Objects/Decoration/mining.yml
+++ b/Resources/Prototypes/Entities/Objects/Decoration/mining.yml
@@ -131,9 +131,7 @@
   name: wooden support wall
   description: An old, rotten wall.
   components:
-  - type: Tag
-    tags:
-    - Wall
+  - type: Wall
   - type: Sprite
     state: support_wall
   - type: Fixtures
@@ -165,9 +163,7 @@
   parent: BaseWoodenSupport
   id: WoodenSupportWallBroken
   components:
-  - type: Tag
-    tags:
-    - Wall
+  - type: Wall
   - type: Sprite
     state: support_wall_broken
   - type: Destructible

--- a/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
+++ b/Resources/Prototypes/Entities/Objects/Devices/chameleon_projector.yml
@@ -27,9 +27,9 @@
       - MindContainer # no
       - Pda # PDAs currently make you invisible /!\
       - SubFloorHide # no hiding under the floor
+      - Wall # Walls make you invisible
       tags:
       - Catwalk # Catwalks make you invisible
-      - Wall # Walls make you invisible
       - Window # Windows make you invisible
     disguiseProto: ChameleonDisguise
   - type: StaticPrice

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/cord.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/cord.yml
@@ -64,9 +64,9 @@
     # whitelist:
       # components:
       # - Airlock
+      # - Wall
       # tags:
       # - Window
-      # - Wall
   # - type: StickyVisualizer
 
 - type: entity

--- a/Resources/Prototypes/Entities/Objects/Weapons/Bombs/spider.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Bombs/spider.yml
@@ -25,8 +25,9 @@
     # can only stick it in target area, no reason to unstick
     canUnstick: false
     whitelist:
-      tags:
+      components:
       - Wall
+      tags:
       - Window
   - type: Explosive # Powerful explosion in a large radius. Will break underplating.
     explosionType: DemolitionCharge

--- a/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
+++ b/Resources/Prototypes/Entities/Objects/Weapons/Guns/Projectiles/magic.yml
@@ -228,7 +228,6 @@
       components:
       - Airlock
       - Firelock
-      tags:
       - Wall
 
 - type: entity

--- a/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
+++ b/Resources/Prototypes/Entities/Structures/Doors/SecretDoor/secret_door.yml
@@ -69,8 +69,8 @@
   - type: Tag
     tags:
     - Structure
-    - Wall
     - ForceNoFixRotations # Don't want the fixrotations command to target these
+  - type: Wall
   - type: ContainerContainer
     containers:
       battery-container: !type:Container

--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -22,9 +22,7 @@
       Heat:
         collection:
           MetalLaserImpact
-  - type: Tag
-    tags:
-    - Wall
+  - type: Wall
   - type: IsRoof
   - type: Sprite
     drawdepth: Walls
@@ -72,7 +70,6 @@
   components:
   - type: Tag
     tags:
-    - Wall
     - Diagonal
   - type: IconSmooth
     mode: Diagonal
@@ -208,7 +205,6 @@
   components:
   - type: Tag
     tags:
-    - Wall
     - Structure
   - type: Sprite
     sprite: Structures/Walls/meat.rsi
@@ -266,9 +262,6 @@
   name: debug wall
   suffix: DEBUG
   components:
-  - type: Tag
-    tags:
-    - Wall
   - type: Sprite
     sprite: Structures/Walls/debug.rsi
   - type: Icon
@@ -975,9 +968,6 @@
   id: WallSolidChitin
   name: solid chitin
   components:
-  - type: Tag
-    tags:
-    - Wall
   - type: Destructible
     thresholds:
     - trigger:
@@ -1334,9 +1324,7 @@
   components:
   - type: TimedDespawn
     lifetime: 15
-  - type: Tag
-    tags:
-    - Wall
+  - type: Wall
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -1357,9 +1345,7 @@
   components:
   - type: TimedDespawn
     lifetime: 10
-  - type: Tag
-    tags:
-    - Wall
+  - type: Wall
   - type: Physics
     bodyType: Static
   - type: Fixtures
@@ -1534,9 +1520,7 @@
       Brute:
         path:
           "/Audio/Weapons/pierce.ogg"
-  - type: Tag
-    tags:
-    - Wall
+  - type: Wall
   - type: Sprite
     drawdepth: SmallObjects #so bullets pass 'through'
     sprite: Structures/Walls/card.rsi

--- a/Resources/Prototypes/tags.yml
+++ b/Resources/Prototypes/tags.yml
@@ -1523,10 +1523,6 @@
 ## W ##
 
 - type: Tag
-  id: Wall # Tagged entity is a wall. Several systems and several targeting whitelists (BaseMobDragon) care about this.
-           # .cs: SharedNavMapSystem, WallmountCondition, TileWallsCommand, DungeonJob
-
-- type: Tag
   id: WallmountGeneratorAPUElectronics # ConstructionGraph: WallmountGenerator
 
 - type: Tag


### PR DESCRIPTION
## What Does This PR Do

Wall-mounted entities are now only visible from the side of the wall they are attached to.
Does not work when FOV is disabled.

Wall tag has also been replaced with a component, WallComponent. 

Ported from Wizden, by request of Tojo
Original PR by B-Kirill
https://github.com/space-wizards/space-station-14/pull/44801
https://github.com/space-wizards/space-station-14/pull/45008

## Why It's Good For The Game

This was requested by mappers, as it is missing functionality.

## Images of changes

https://github.com/user-attachments/assets/e2f4d87c-6769-4a18-9dbc-4bafdec540dc


https://github.com/user-attachments/assets/983cbc43-96eb-410f-beb8-0b63352fbac9


https://github.com/user-attachments/assets/8a46f4eb-f7d3-4b23-9dbb-840958ae9a8e


## Technical details
Can be disabled by the server using the corresponding CVar.

There will be issues with existing maps. For example, wall-mounted fire extinguishers have rotation in all directions, but many of them face south.

## Declaration

- [x] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->
  
<img width="818" height="303" alt="image" src="https://github.com/user-attachments/assets/3749f5c6-4f60-485e-bc20-b6cc0de1db72" />

## Licensing
<!-- This is for the benefit of other forks wishing to port features from Paradise SS14 -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] MIT (https://github.com/ParadiseSS14/Paradise14/blob/master/LICENSE-MIT.txt) <!-- This is required to contribute to ParadiseSS14 -->
    <!-- Feel free to add more licenses as you see fit -->

## Changelog
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
:cl: B_Kirill, mirrorcult
- tweak: Wall-mounted entities are now only visible from the side of the wall they are attached to.
- tweak: "Wall" tag replaced with WallComponent
