### PR TITLE
Prettier fix errors in VSC

### DIFF
--- a/BuildChecker/git_helper.py
+++ b/BuildChecker/git_helper.py
@@ -13,7 +13,7 @@ from typing import List
 
 SOLUTION_PATH = Path("..") / "SpaceStation14.slnx"
 # If this doesn't match the saved version we overwrite them all.
-CURRENT_HOOKS_VERSION = "5"
+CURRENT_HOOKS_VERSION = "6"
 QUIET = len(sys.argv) == 2 and sys.argv[1] == "--quiet"
 
 

--- a/BuildChecker/hooks/pre-commit
+++ b/BuildChecker/hooks/pre-commit
@@ -13,14 +13,12 @@ mapfile -t files < <(
 if (( ${#files[@]} != 0 )); then
 
     if ! command -v npm >/dev/null 2>&1; then
-        echo "Node.js/npm is required to check YAML formatting."
-        echo "Install Node.js, then run: npm ci --prefix Tools/prettier"
+        echo "Node.js/npm is required to check YAML formatting. Install Node.js, then run: npm ci --prefix Tools/prettier"
         exit 1
     fi
 
     if [[ ! -x Tools/prettier/node_modules/.bin/prettier && ! -f Tools/prettier/node_modules/.bin/prettier.cmd ]]; then
-        echo "Prettier is not installed."
-        echo "Run: npm ci --prefix Tools/prettier"
+        echo "Prettier is not installed. Run: npm ci --prefix Tools/prettier"
         exit 1
     fi
 fi


### PR DESCRIPTION
## What Does This PR Do

Makes the Prettier setup errors self-contained, so VS Code users see the required installation command directly in the Git error dialog.

## Testing

<img width="689" height="212" alt="image" src="https://github.com/user-attachments/assets/9e5b80f7-b5a1-43ac-99bb-5905d7746955" />

## Declaration

- [ x] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from Paradise SS14 -->
- [x ] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] MIT (https://github.com/ParadiseSS14/Paradise14/blob/master/LICENSE-MIT.txt) <!-- This is required to contribute to ParadiseSS14 -->
    <!-- Feel free to add more licenses as you see fit -->

