### PR TITLE
Fix yaml line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,6 +3,10 @@
 ###############################################################################
 * text=auto
 
+# Keep YAML formatting consistent across platforms.
+*.yml  text eol=lf
+*.yaml text eol=lf
+
 ###############################################################################
 # Set default behavior for command prompt diff.
 #

--- a/BuildChecker/git_helper.py
+++ b/BuildChecker/git_helper.py
@@ -13,7 +13,7 @@ from typing import List
 
 SOLUTION_PATH = Path("..") / "SpaceStation14.slnx"
 # If this doesn't match the saved version we overwrite them all.
-CURRENT_HOOKS_VERSION = "6"
+CURRENT_HOOKS_VERSION = "7"
 QUIET = len(sys.argv) == 2 and sys.argv[1] == "--quiet"
 
 

--- a/BuildChecker/hooks/pre-commit
+++ b/BuildChecker/hooks/pre-commit
@@ -21,6 +21,17 @@ if (( ${#files[@]} != 0 )); then
         echo "Prettier is not installed. Run: npm ci --prefix Tools/prettier"
         exit 1
     fi
-fi
 
-npm --prefix Tools/prettier run prettier:check -- "${files[@]/#/../../}"
+    # Capture npm output so VS Code shows our actionable message first.
+    # `|| status=$?` prevents `set -e` from exiting before we can print it.
+    status=0
+    prettier_output=$(npm --prefix Tools/prettier run prettier:check -- "${files[@]/#/../../}" 2>&1) || status=$?
+
+    if (( status != 0 )); then
+        echo "YAML formatting check failed. Run: npm --prefix Tools/prettier run prettier:write -- ../../Resources/Prototypes"
+        echo "$prettier_output"
+        exit "$status"
+    fi
+
+    echo "$prettier_output"
+fi

--- a/Tools/prettier/package.json
+++ b/Tools/prettier/package.json
@@ -3,7 +3,7 @@
     "prettier": "3.9.6"
   },
   "scripts": {
-    "prettier:check": "prettier --check",
-    "prettier:write": "prettier --write"
+    "prettier:check": "prettier --check --end-of-line auto",
+    "prettier:write": "prettier --write --end-of-line auto"
   }
 }


### PR DESCRIPTION
## What Does This PR Do

Prevents Prettier from producing line-ending-only diffs for YAML files on Windows.
YAML files use LF in new checkouts, while Prettier preserves the line endings already present in existing working trees.
Failed check will promt you to run proper command.

## Testing
Branch doesn't produce crlf-cl diffs, after running
`npm --prefix Tools/prettier run prettier:write -- ../../Resources/Prototypes`

new error will look like this:
<img width="568" height="143" alt="image" src="https://github.com/user-attachments/assets/079eba80-16d3-4958-bedb-991f75925a4a" />


## Declaration

- [ x] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from Paradise SS14 -->
- [x] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] MIT (https://github.com/ParadiseSS14/Paradise14/blob/master/LICENSE-MIT.txt) <!-- This is required to contribute to ParadiseSS14 -->
    <!-- Feel free to add more licenses as you see fit -->


