### PR TITLE
Small Adjustments to Cryostorage Menu .XAML

### DIFF
--- a/Content.Client/Bed/Cryostorage/CryostorageEntryControl.xaml
+++ b/Content.Client/Bed/Cryostorage/CryostorageEntryControl.xaml
@@ -7,11 +7,14 @@
     Orientation="Vertical"
     HorizontalExpand="True"
     Margin="0 0 0 5">
-    <PanelContainer StyleClasses="PanelDark">
+    <PanelContainer StyleClasses="SurfacePrimary">
         <Collapsible Name="Collapsible">
-            <CollapsibleHeading Name="Heading" MinHeight="35"/>
-            <CollapsibleBody Name="Body">
-                <BoxContainer Name="ItemsContainer" Orientation="Vertical" HorizontalExpand="True"/>
+            <CollapsibleHeading Name="Heading" MinHeight="35" StyleClasses="PanelDark"/>
+            <CollapsibleBody Name="Body" StyleClasses="SurfacePrimary">
+                <BoxContainer Name="ItemsContainer"
+                 Orientation="Vertical"
+                 HorizontalExpand="True"
+                 StyleClasses="SurfacePrimary"/>
             </CollapsibleBody>
         </Collapsible>
     </PanelContainer>

--- a/Content.Client/Bed/Cryostorage/CryostorageEntryControl.xaml
+++ b/Content.Client/Bed/Cryostorage/CryostorageEntryControl.xaml
@@ -9,12 +9,16 @@
     Margin="0 0 0 5">
     <PanelContainer StyleClasses="SurfacePrimary">
         <Collapsible Name="Collapsible">
-            <CollapsibleHeading Name="Heading" MinHeight="35" StyleClasses="PanelDark"/>
+            <CollapsibleHeading Name="Heading"
+                MinHeight="35"
+                StyleClasses="PanelDark"
+                Margin="5"/>
             <CollapsibleBody Name="Body" StyleClasses="SurfacePrimary">
                 <BoxContainer Name="ItemsContainer"
                  Orientation="Vertical"
                  HorizontalExpand="True"
-                 StyleClasses="SurfacePrimary"/>
+                 StyleClasses="SurfacePrimary"
+                 Margin="5"/>
             </CollapsibleBody>
         </Collapsible>
     </PanelContainer>

--- a/Content.Client/Bed/Cryostorage/CryostorageMenu.xaml
+++ b/Content.Client/Bed/Cryostorage/CryostorageMenu.xaml
@@ -15,10 +15,14 @@
             VerticalExpand="True"
             HorizontalExpand="True"
             Margin="15"
-            StyleClasses="PanelDark">
+            StyleClasses="SurfacePrimary">
             <ScrollContainer VerticalExpand="True" HorizontalExpand="True">
                 <Control>
-                    <Label Text="{Loc 'cryostorage-ui-label-no-bodies'}" Name="EmptyLabel" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                    <Label Text="{Loc 'cryostorage-ui-label-no-bodies'}"
+                           Name="EmptyLabel"
+                           HorizontalAlignment="Left"
+                           VerticalAlignment="Top"
+                           Margin="10"/>
                     <BoxContainer Name="EntriesContainer"
                                   Orientation="Vertical"
                                   Margin="10"


### PR DESCRIPTION
## What Does This PR Do

This PR makes small adjustments to Cryostorage Menu .XAML to align it somewhat with other machine GUIs.

## Why It's Good For The Game

This PR attempts to address a criticism of the Cryostorage Menu GUI mentioned in [this Issue thread](https://github.com/ParadiseSS14/Paradise/issues/50) .

## Images of changes

The new GUIs are presented on the right:

<img width="918" height="854" alt="xaml adjustment" src="https://github.com/user-attachments/assets/23943241-b4bc-434f-9107-e9e95472755c" />

## Testing

I opened an empty Cryostorage Menu GUI in the test server and the images presented above to the right are how the GUI appeared in its various states.

## Declaration

- [x] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

## Licensing
<!-- This is for the benefit of other forks wishing to port features from Paradise SS14 -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] MIT (https://github.com/ParadiseSS14/Paradise14/blob/master/LICENSE-MIT.txt) <!-- This is required to contribute to ParadiseSS14 -->
