### PR TITLE
Posters and signs can now face directions other than south

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
@@ -5,7 +5,7 @@
   abstract: true
   components:
     - type: WallMount
-      arc: 360
+      arc: 180
     - type: Rotatable
     - type: Destructible
       thresholds:

--- a/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
+++ b/Resources/Prototypes/Entities/Structures/Wallmounts/Signs/base_structuresigns.yml
@@ -16,7 +16,7 @@
               acts: ["Destruction"]
     - type: Sprite
       sprite: Structures/Wallmounts/signs.rsi
-      snapCardinals: true
+      snapCardinals: false
     - type: StaticPrice
       price: 20
     # Hacky wacky - It inherit anchorable from "BaseWallmount", none of the BaseSign children are designed to be anchorable


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Simply turns off snapcardinals for base sign prototype.
All signs and posters can now rotate.
<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Para13 Soul (they could rotate in paradise 13)
Better for mapping for specific areas
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Images of changes

<img width="340" height="755" alt="image" src="https://github.com/user-attachments/assets/77c321ca-1413-4e76-8129-453a31fcfe94" />

<img width="569" height="391" alt="Content Client_KFZlHbAC5i" src="https://github.com/user-attachments/assets/3338a80e-f528-4e3f-8d75-476fa44b82ef" />

Spawners also spawn them facing the correct direction.

<!-- If you did not make a map or sprite edit, you may delete this section. You may include a gif or mp4 of your feature if you want. -->

## Declaration

- [X] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from Paradise SS14 -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] MIT (https://github.com/ParadiseSS14/Paradise14/blob/master/LICENSE-MIT.txt) <!-- This is required to contribute to ParadiseSS14 -->
    <!-- Feel free to add more licenses as you see fit -->

## Changelog
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
:cl:
- tweak: Posters and signs can now rotate


