### PR TITLE
Adding BlindedByFlashingComponent

### DIFF
--- a/Content.Shared/Flash/Components/_Paradise/BlindedByFlashingComponent.cs
+++ b/Content.Shared/Flash/Components/_Paradise/BlindedByFlashingComponent.cs
@@ -1,0 +1,18 @@
+using Robust.Shared.GameStates;
+
+namespace Content.Shared.Flash._Paradise.Components;
+
+/// <summary>
+/// This entity will take eye damage from flashes.
+/// Copied from DamagedByFlashingComponent
+/// </summary>
+[RegisterComponent, NetworkedComponent]
+[Access(typeof(BlindedByFlashingSystem))]
+public sealed partial class BlindedByFlashingComponent : Component
+{
+    /// <summary>
+    /// How much damage it will take.
+    /// </summary>
+    [DataField(required: true)]
+    public int EyeDamage;
+}

--- a/Content.Shared/Flash/Components/_Paradise/BlindedByFlashingComponent.cs
+++ b/Content.Shared/Flash/Components/_Paradise/BlindedByFlashingComponent.cs
@@ -6,13 +6,16 @@ namespace Content.Shared.Flash._Paradise.Components;
 /// This entity will take eye damage from flashes.
 /// Copied from DamagedByFlashingComponent
 /// </summary>
-[RegisterComponent, NetworkedComponent]
+[RegisterComponent]
 [Access(typeof(BlindedByFlashingSystem))]
 public sealed partial class BlindedByFlashingComponent : Component
 {
     /// <summary>
     /// How much damage it will take.
     /// </summary>
+    /// <remarks>
+    /// The maximum damage before total blindness in BlindableSystem is 9, so 3 flashes would blind if you set damage to 3. Two if you set it to 5, etc.  
+    /// </remarks>
     [DataField(required: true)]
     public int EyeDamage;
 }

--- a/Content.Shared/Flash/Components/_Paradise/BlindedByFlashingComponent.cs
+++ b/Content.Shared/Flash/Components/_Paradise/BlindedByFlashingComponent.cs
@@ -1,5 +1,3 @@
-using Robust.Shared.GameStates;
-
 namespace Content.Shared.Flash._Paradise.Components;
 
 /// <summary>

--- a/Content.Shared/Flash/FlashEvents.cs
+++ b/Content.Shared/Flash/FlashEvents.cs
@@ -20,8 +20,10 @@ public record struct FlashAttemptEvent(EntityUid Target, EntityUid? User, Entity
 [ByRefEvent]
 public record struct AfterFlashedEvent(EntityUid Target, EntityUid? User, EntityUid? Used, bool Melee)
 {
-    // Has this flash event been handled? Prevents extra flash damage.
-    public bool Handled;
+    /// <summary>
+    /// Has this flash event been handled? Prevents extra flash damage.
+    /// </summary>
+    public bool Handled; // Paradise Change
 }
 
 /// <summary>

--- a/Content.Shared/Flash/FlashEvents.cs
+++ b/Content.Shared/Flash/FlashEvents.cs
@@ -18,7 +18,11 @@ public record struct FlashAttemptEvent(EntityUid Target, EntityUid? User, Entity
 /// The Melee parameter is used to check for rev conversion.
 /// </summary>
 [ByRefEvent]
-public record struct AfterFlashedEvent(EntityUid Target, EntityUid? User, EntityUid? Used, bool Melee);
+public record struct AfterFlashedEvent(EntityUid Target, EntityUid? User, EntityUid? Used, bool Melee)
+{
+    // Has this flash event been handled? Prevents extra flash damage.
+    public bool Handled;
+}
 
 /// <summary>
 /// Raised once on the flash entity when it was used, regardless of the flashed status being applied or not.

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -242,7 +242,7 @@ public abstract partial class SharedFlashSystem : EntitySystem
         var ev = new AfterFlashedEvent(target, user, used, melee);
         RaiseLocalEvent(target, ref ev);
 
-        if (user != null)
+        if (user != null && user != target)
             RaiseLocalEvent(user.Value, ref ev);
         if (used != null)
             RaiseLocalEvent(used.Value, ref ev);

--- a/Content.Shared/Flash/SharedFlashSystem.cs
+++ b/Content.Shared/Flash/SharedFlashSystem.cs
@@ -242,7 +242,7 @@ public abstract partial class SharedFlashSystem : EntitySystem
         var ev = new AfterFlashedEvent(target, user, used, melee);
         RaiseLocalEvent(target, ref ev);
 
-        if (user != null && user != target)
+        if (user != null && user != target) // Paradise Change
             RaiseLocalEvent(user.Value, ref ev);
         if (used != null)
             RaiseLocalEvent(used.Value, ref ev);

--- a/Content.Shared/Flash/_Paradise/BlindedbyFlashingSystem.cs
+++ b/Content.Shared/Flash/_Paradise/BlindedbyFlashingSystem.cs
@@ -1,0 +1,24 @@
+using Content.Shared.Flash._Paradise.Components;
+using Content.Shared.Eye.Blinding.Systems;
+
+namespace Content.Shared.Flash._Paradise;
+
+/// <summary>
+/// Modifies eye damage by a given amount.
+/// Copied from DamagedByFlashingSystem
+/// </summary>
+public sealed partial class BlindedByFlashingSystem : EntitySystem
+{
+    [Dependency] private BlindableSystem _blindable = default!;
+
+    public override void Initialize()
+    {
+        base.Initialize();
+        SubscribeLocalEvent<BlindedByFlashingComponent, FlashAttemptEvent>(OnFlashAttempt);
+    }
+
+    private void OnFlashAttempt(Entity<BlindedByFlashingComponent> ent, ref FlashAttemptEvent args)
+    {
+        _blindable.AdjustEyeDamage(ent.Owner, ent.Comp.EyeDamage);
+    }
+}

--- a/Content.Shared/Flash/_Paradise/BlindedbyFlashingSystem.cs
+++ b/Content.Shared/Flash/_Paradise/BlindedbyFlashingSystem.cs
@@ -14,12 +14,18 @@ public sealed partial class BlindedByFlashingSystem : EntitySystem
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<BlindedByFlashingComponent, AfterFlashedEvent>(OnFlashAttempt);
+        SubscribeLocalEvent<BlindedByFlashingComponent, AfterFlashedEvent>(OnAfterFlashed);
     }
 
-    private void OnFlashAttempt(Entity<BlindedByFlashingComponent> ent, ref AfterFlashedEvent args)
+    private void OnAfterFlashed(Entity<BlindedByFlashingComponent> ent, ref AfterFlashedEvent args)
     {
+        if (args.Handled)
+            return;
+
         if (args.Target == ent.Owner)
+        {
             _blindable.AdjustEyeDamage(ent.Owner, ent.Comp.EyeDamage);
+            args.Handled = true;
+        }
     }
 }

--- a/Content.Shared/Flash/_Paradise/BlindedbyFlashingSystem.cs
+++ b/Content.Shared/Flash/_Paradise/BlindedbyFlashingSystem.cs
@@ -1,5 +1,6 @@
-using Content.Shared.Flash._Paradise.Components;
 using Content.Shared.Eye.Blinding.Systems;
+using Content.Shared.Flash._Paradise.Components;
+using Content.Shared.Inventory;
 
 namespace Content.Shared.Flash._Paradise;
 
@@ -10,15 +11,17 @@ namespace Content.Shared.Flash._Paradise;
 public sealed partial class BlindedByFlashingSystem : EntitySystem
 {
     [Dependency] private BlindableSystem _blindable = default!;
+    [Dependency] private InventorySystem _inventory = default!;
 
     public override void Initialize()
     {
         base.Initialize();
-        SubscribeLocalEvent<BlindedByFlashingComponent, FlashAttemptEvent>(OnFlashAttempt);
+        SubscribeLocalEvent<BlindedByFlashingComponent, AfterFlashedEvent>(OnFlashAttempt);
     }
 
-    private void OnFlashAttempt(Entity<BlindedByFlashingComponent> ent, ref FlashAttemptEvent args)
+    private void OnFlashAttempt(Entity<BlindedByFlashingComponent> ent, ref AfterFlashedEvent args)
     {
-        _blindable.AdjustEyeDamage(ent.Owner, ent.Comp.EyeDamage);
+        if (args.Target == ent.Owner)
+            _blindable.AdjustEyeDamage(ent.Owner, ent.Comp.EyeDamage);
     }
 }

--- a/Content.Shared/Flash/_Paradise/BlindedbyFlashingSystem.cs
+++ b/Content.Shared/Flash/_Paradise/BlindedbyFlashingSystem.cs
@@ -1,6 +1,5 @@
 using Content.Shared.Eye.Blinding.Systems;
 using Content.Shared.Flash._Paradise.Components;
-using Content.Shared.Inventory;
 
 namespace Content.Shared.Flash._Paradise;
 
@@ -11,7 +10,6 @@ namespace Content.Shared.Flash._Paradise;
 public sealed partial class BlindedByFlashingSystem : EntitySystem
 {
     [Dependency] private BlindableSystem _blindable = default!;
-    [Dependency] private InventorySystem _inventory = default!;
 
     public override void Initialize()
     {


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

This adds a new system and component that utilizes the existing BlindableSystem to allow eye damage from flashes. The amount of damage is adjustable in the component DataField. 

The maximum damage before total blindness in BlindableSystem is 9, so 3 flashes would blind if you set damage to 3. Two if you set it to 5, etc. BlindableSystem has a varying overlays that change as the damage progresses. It's already fairly debilitating at 6. 

Damage heals with oculine and carrots.

Originally thrown together for Greys, but other species need this too (nian, tajaran, drask, etc). Not currently tied to night vision like Paradise13 is, but it works.

Example of adding it to a mob prototype:
```
   - type: BlindedByFlashing
     eyeDamage: 3
```

<!-- Include a small to medium description of what your PR changes. -->
<!-- Document all changes, as not doing this may delay reviews or even discourage maintainers from merging your PR! -->
<!-- If your PR fixes an issue, add "Fixes #1234" somewhere in the PR description. This will automatically close the bug upon PR submission. -->

## Why It's Good For The Game

Effective bullying of Nian players.
<!-- Add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Testing

Applied component to Grey. Spawned flash. Flashed self until blind.
<!-- How did you test the PR, if at all? -->

## Declaration

- [X] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.

   MVP (?)
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from Paradise SS14 -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] MIT (https://github.com/ParadiseSS14/Paradise14/blob/master/LICENSE-MIT.txt) <!-- This is required to contribute to ParadiseSS14 -->
    <!-- Feel free to add more licenses as you see fit -->

## Changelog
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
:cl:
- add: Add Flash Blinding System

