### PR TITLE
Attempts a fix to access helpers when loading grids

### DIFF
--- a/Content.Server/Mapping/_Paradise/Helpers/Systems/AccessHelperSystem.cs
+++ b/Content.Server/Mapping/_Paradise/Helpers/Systems/AccessHelperSystem.cs
@@ -1,22 +1,20 @@
 ﻿using System.Diagnostics.CodeAnalysis;
 using Content.Server._Paradise.GameObjects.GatherTargets;
-using Content.Shared.Access.Components;
 using Content.Shared.Access.Systems;
 using Content.Shared.Doors.Components;
 using Content.Shared.Tag;
-using Robust.Shared.Containers;
 using Robust.Shared.Prototypes;
 
 namespace Content.Server._Paradise.AccessHelper
 {
     public sealed partial class AccessHelperSystem : EntitySystem
     {
-        [Dependency] private SharedContainerSystem _containerSystem = default!;
         [Dependency] private AccessReaderSystem _accessReaderSystem = default!;
         [Dependency] private TagSystem _tagSystem = default!;
 
         private static readonly ProtoId<TagPrototype> TagWindoor = "Windoor";
         private static readonly ProtoId<TagPrototype> TagWindoorHelper = "WindoorHelper";
+        private readonly List<(EntityUid helper, Entity<AirlockComponent> door) > _pending = new();
 
         public override void Initialize()
         {
@@ -43,9 +41,9 @@ namespace Content.Server._Paradise.AccessHelper
             }
 
             // Does our door have an AccessComponent inside it?
-            if (!GetAccessComponent(door.Value.Owner, out var accessReader))
+            if (!_accessReaderSystem.GetMainAccessReader(door.Value.Owner, out var accessReader))
             {
-                Log.Warning($"Access Helper (Uid {entity.Owner}) was placed on top of {door.Value.Owner} at {Transform(entity.Owner).Coordinates} which has no AccessReader inside it.");
+                Log.Warning($"Access Helper (Uid {entity.Owner}) was placed on top of an airlock (Uid {door.Value.Owner}) at {Transform(entity.Owner).Coordinates} which has no AccessReader inside it.");
                 QueueDel(entity.Owner);
                 return;
             }
@@ -58,9 +56,44 @@ namespace Content.Server._Paradise.AccessHelper
                 return;
             }
 
+            if (accessReader.Value.Owner == door.Value.Owner)
+            {
+                _pending.Add((entity.Owner, door.Value));
+                return;
+            }
+
+            Log.Warning($"Access Helper (Uid {entity.Owner}) attempted to add access {entity.Comp.Access} to access reader {accessReader} of entity {entity.Owner}");
             _accessReaderSystem.TryAddAccess(accessReader.Value, entity.Comp.Access.Value);
             QueueDel(entity.Owner);
         }
+
+        public override void Update(float frameTime)
+        {
+            for (var i = _pending.Count - 1; i >= 0; i--)
+            {
+                var (helperUid, door) = _pending[i];
+
+                if (!TryComp<AccessHelperComponent>(helperUid, out var helperComponent) || helperComponent.Access is null)
+                {
+                    _pending.RemoveAt(i);
+                    continue;
+                }
+
+                if (!_accessReaderSystem.GetMainAccessReader(door.Owner, out var accessReader))
+                {
+                    _pending.RemoveAt(i);
+                    continue;
+                }
+
+                if (accessReader.Value.Owner == door.Owner)
+                    continue;
+
+                _accessReaderSystem.TryAddAccess(accessReader.Value, helperComponent.Access.Value);
+                QueueDel(helperUid);
+                _pending.RemoveAt(i);
+            }
+        }
+
 
         // Do we have a door on our grid?
         private bool FindDoor(IEnumerable<EntityUid> tileEntities, Angle helperAngle, bool isWindoorHelper, [NotNullWhen(true)] out Entity<AirlockComponent>? door)
@@ -73,7 +106,6 @@ namespace Content.Server._Paradise.AccessHelper
                 // Checks if the door has airlockcomponent, returns false if not found
                 if (!TryComp<AirlockComponent>(entityUid, out var airlockComp))
                 {
-                    Log.Warning("Failed to find component!");
                     continue;
                 }
 
@@ -108,25 +140,5 @@ namespace Content.Server._Paradise.AccessHelper
             return true;
         }
 
-        // Get the access component from inside the door
-        private bool GetAccessComponent(EntityUid doorUid, [NotNullWhen(true)] out Entity<AccessReaderComponent>? accessReader)
-        {
-            accessReader = null;
-            // Checks if the door has a container, returns true if found
-            if (!_containerSystem.TryGetContainer(doorUid, "board", out var container))
-                return false;
-            /* Searches every entityUid in the door's container. When it finds an entity with the AccessReaderComponent, it stops
-               and combines the entityUid and component in a tuple.*/
-            foreach (var entityUid in container.ContainedEntities)
-            {
-                if (TryComp<AccessReaderComponent>(entityUid, out var reader))
-                {
-                    accessReader = (entityUid, reader);
-                    return true;
-                }
-            }
-
-            return false;
-        }
     }
 }

--- a/Content.Server/Mapping/_Paradise/Helpers/Systems/AccessHelperSystem.cs
+++ b/Content.Server/Mapping/_Paradise/Helpers/Systems/AccessHelperSystem.cs
@@ -14,7 +14,8 @@ namespace Content.Server._Paradise.AccessHelper
 
         private static readonly ProtoId<TagPrototype> TagWindoor = "Windoor";
         private static readonly ProtoId<TagPrototype> TagWindoorHelper = "WindoorHelper";
-        private readonly List<(EntityUid helper, Entity<AirlockComponent> door) > _pending = new();
+        private readonly List<(EntityUid helper, Entity<AirlockComponent> door, int attempts) > _pending = new();
+        private const int MaxUpdateAttempts = 100;
 
         public override void Initialize()
         {
@@ -58,7 +59,8 @@ namespace Content.Server._Paradise.AccessHelper
 
             if (accessReader.Value.Owner == door.Value.Owner)
             {
-                _pending.Add((entity.Owner, door.Value));
+
+                _pending.Add((entity.Owner, door.Value, 0));
                 return;
             }
 
@@ -67,26 +69,35 @@ namespace Content.Server._Paradise.AccessHelper
             QueueDel(entity.Owner);
         }
 
+        // Update our helpers until they find an accessreader (incase we initialize before it)
         public override void Update(float frameTime)
         {
+
             for (var i = _pending.Count - 1; i >= 0; i--)
             {
-                var (helperUid, door) = _pending[i];
-
+                var (helperUid, door, attempts) = _pending[i];
                 if (!TryComp<AccessHelperComponent>(helperUid, out var helperComponent) || helperComponent.Access is null)
                 {
                     _pending.RemoveAt(i);
                     continue;
                 }
-
                 if (!_accessReaderSystem.GetMainAccessReader(door.Owner, out var accessReader))
                 {
                     _pending.RemoveAt(i);
                     continue;
                 }
-
                 if (accessReader.Value.Owner == door.Owner)
+                {
+                    if (attempts + 1 >= MaxUpdateAttempts)
+                    {
+                        Log.Warning($"Access Reader {accessReader.Value.Owner} failed to add an access after 100 ticks. Deleting...");
+                        QueueDel(helperUid);
+                        _pending.RemoveAt(i);
+                        continue;
+                    }
+                    _pending[i] = (helperUid, door, attempts + 1);
                     continue;
+                }
 
                 _accessReaderSystem.TryAddAccess(accessReader.Value, helperComponent.Access.Value);
                 QueueDel(helperUid);


### PR DESCRIPTION
<!-- By ticking or leaving ticked the option "Allow edits and access to secrets by maintainers" you give permission for repository maintainers to push changes to your branch without explicitly asking. -->

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## What Does This PR Do

Windoors seem to have a problem with initializing too late for access helpers code to find their access reader.

This PR is attempting to fix that.

This is probably NOT the best way to do this, but I'm leaving this open for maintainers to go ahead and tell me my way is terrible.

## Why It's Good For The Game

Bug fix


## Testing

Loaded a grid with access helpers, did indeed work.

## Declaration

- [X] I confirm that I either do not require pre-approval for this PR, or I have obtained such approval and have included a screenshot to demonstrate this below.
  <!-- Replace the box with [x] to mark as complete. -->
  <!-- Ensure there are no spaces between the x and the square brackets [] else this will not work properly. -->

## Licensing
<!-- This is for the benefit of other forks wishing to port features from Paradise SS14 -->
- [X] I confirm that I am the creator of the code in this PR, and allow licensing it under the following license(s), or that the original author(s) has given me permission to do so:
  - [X] MIT (https://github.com/ParadiseSS14/Paradise14/blob/master/LICENSE-MIT.txt) <!-- This is required to contribute to ParadiseSS14 -->
    <!-- Feel free to add more licenses as you see fit -->

## Changelog
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
<!-- If a PR has no impact on players (i.e. a code refactor that does not change functionality) then the entire Changelog heading and contents can be removed. -->
:cl:
- fix: Access Helpers work on gridload for windoors now

